### PR TITLE
Fixed filtering according to the latest changes

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -25,9 +25,3 @@ export const apiKey = process.env.ADMIN_API_KEY ?? '';
 // which throws an error upon finding an inappropriate prompt
 export const filterServerUrl =
   process.env.FILTER_SERVICE_URL ?? 'http://localhost:8080/filter';
-
-// The URL for prompt filtering endpoint,
-// which doesn't throw any errors and
-// always returns a filtered prompt as a result
-export const noErrorFilterServerUrl =
-  process.env.FILTER_SERVICE_URL2 ?? 'http://localhost:8080/filter/no-error';

--- a/src/router/imageProcessRouter.ts
+++ b/src/router/imageProcessRouter.ts
@@ -7,6 +7,7 @@ import { Request, Response, Router } from 'express';
 import { check, validationResult } from 'express-validator';
 import { IImageResponse } from '../interface/iImageResponse';
 import { PromptModel } from '../model/promptModel';
+import {filterPrompt} from '../service/PromptService';
 
 const router = Router();
 
@@ -36,9 +37,15 @@ router.post(
       switch (method) {
         case 'text': {
           try {
-            // await filterPrompt(prompt);
+            const filteredPrompt = await filterPrompt(prompt);
+            // If the returned prompt is empty, it means that it was inappropriate.
+            // Thus, ignore the prompt.
+            if (filteredPrompt.length === 0)
+              break;
+
+            console.log('The prompt passed successfully');
             const newPrompt = {
-              prompt: prompt,
+              prompt: filteredPrompt,
               approved: false,
               isUsed: false,
             };
@@ -65,9 +72,14 @@ router.post(
         }
         default: {
           try {
-            // await filterPrompt(prompt);
+            const filteredPrompt = await filterPrompt(prompt);
+            // If the returned prompt is empty, it means that it was inappropriate.
+            // Thus, ignore the prompt.
+            if (filteredPrompt.length === 0)
+              break;
+
             const newPrompt = {
-              prompt: prompt,
+              prompt: filteredPrompt,
               approved: false,
               isUsed: false,
             };

--- a/src/service/PromptService.ts
+++ b/src/service/PromptService.ts
@@ -1,12 +1,12 @@
 import { Client } from 'minio';
 import {
+  filterServerUrl,
   minioAccessKey,
   minioAccessSecret,
   minioEndpoint,
   minioPort,
   minioPublicEndpoint,
   minioPublicPort,
-  noErrorFilterServerUrl,
 } from '../config/config';
 import axios from 'axios';
 import { NegativePrompts } from '../config/negativePrompts';
@@ -35,15 +35,15 @@ export const filterPrompt = async (prompt: string) => {
   // This option throws errors and returns a filtered prompt.
   // In case of encountering the first inappropriate/forbidden word/phrase,
   // or indicating an unsupported language, an error is thrown.
-  // const response = await axios.post(filterServerUrl, {prompt});
+  const response = await axios.post(filterServerUrl, {prompt})
+      .catch(() => { return null;});
 
-  // This option doesn't throw errors and returns a filtered prompt.
-  // If something went wrong: the prompt was in unsupported language,
-  // then an empty string is returned instead of an error.
-  const response = await axios.post(noErrorFilterServerUrl, { prompt });
-
-  if (response.status === 400 || response.status === 500)
-    throw Error(response.data.message);
+  // In case of encountering inappropriate prompt and getting an error from filtering,
+  // return an empty string.
+  // To throw an error instead, delete this "if-statement" and the "catch function above".
+  // If the API request is with 4XX or 5XX codes, it will throw an error automatically.
+  if (!response)
+    return '';
 
   return response.data.prompt;
 };


### PR DESCRIPTION
Now filter completely ignores the prompt if it's inappropriate and keeps it if it isn't. Also, cleaned code and left only the filtering API option that throws an error when "bad words" encountered, as we won't need the "no-error" option